### PR TITLE
新增: 批量替换gitcode为github

### DIFF
--- a/csdngreener_greasyfork.user.js
+++ b/csdngreener_greasyfork.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         「CSDNGreener」🍃CSDN广告完全过滤|免登录|个性化排版|最强老牌脚本|持续更新
 // @namespace    https://github.com/adlered
-// @version      4.2.3
+// @version      4.2.4
 // @description  ⚡️全新4.0版本！拥有数项独家功能的最强CSDN脚本，不服比一比⚡️|🕶无需登录CSDN，获得比会员更佳的体验|🖥自定义背景图，分辨率自适配，分屏不用滚动|💾超级预优化|🔖独家超级免会员|🏷独家原创文章免登录展开|🔌独家推荐内容自由开关|📠独家免登录复制|🔗独家防外链重定向|📝独家论坛未登录自动展开文章、评论|🌵全面净化|📈沉浸阅读|🧴净化剪贴板|📕作者信息文章顶部展示
 // @author       Adler
 // @connect      www.csdn.net
@@ -16,6 +16,7 @@
 // @grant        GM_getValue
 // @license      AGPL-3.0-or-later
 // @antifeature  ads CSDNGreener 脚本中嵌入了可一键永久关闭的小广告，不会影响您的使用体验:) 请放心安装！
+// @note         24-03-28 4.2.4 批量替换gitcode为github
 // @note         24-03-28 4.2.3 标题更改
 // @note         23-12-21 4.2.2 修复了一些已知问题
 // @note         23-12-16 4.2.1 文章页牛皮癣优化
@@ -164,7 +165,7 @@
 // @downloadURL https://update.greasyfork.org/scripts/378351/%F0%9F%94%A5%E6%8C%81%E7%BB%AD%E6%9B%B4%E6%96%B0%F0%9F%94%A5%20CSDN%E5%B9%BF%E5%91%8A%E5%AE%8C%E5%85%A8%E8%BF%87%E6%BB%A4%E3%80%81%E4%BA%BA%E6%80%A7%E5%8C%96%E8%84%9A%E6%9C%AC%E4%BC%98%E5%8C%96%EF%BC%9A%F0%9F%86%95%20%E4%B8%8D%E7%94%A8%E5%86%8D%E7%99%BB%E5%BD%95%E4%BA%86%EF%BC%81%E8%AE%A9%E4%BD%A0%E4%BD%93%E9%AA%8C%E4%BB%A4%E4%BA%BA%E6%83%8A%E5%96%9C%E7%9A%84%E5%B4%AD%E6%96%B0CSDN%E3%80%82.user.js
 // @updateURL https://update.greasyfork.org/scripts/378351/%F0%9F%94%A5%E6%8C%81%E7%BB%AD%E6%9B%B4%E6%96%B0%F0%9F%94%A5%20CSDN%E5%B9%BF%E5%91%8A%E5%AE%8C%E5%85%A8%E8%BF%87%E6%BB%A4%E3%80%81%E4%BA%BA%E6%80%A7%E5%8C%96%E8%84%9A%E6%9C%AC%E4%BC%98%E5%8C%96%EF%BC%9A%F0%9F%86%95%20%E4%B8%8D%E7%94%A8%E5%86%8D%E7%99%BB%E5%BD%95%E4%BA%86%EF%BC%81%E8%AE%A9%E4%BD%A0%E4%BD%93%E9%AA%8C%E4%BB%A4%E4%BA%BA%E6%83%8A%E5%96%9C%E7%9A%84%E5%B4%AD%E6%96%B0CSDN%E3%80%82.meta.js
 // ==/UserScript==
-var version = "4.2.3";
+var version = "4.2.4";
 var currentURL = window.location.href;
 if (currentURL.indexOf("?") !== -1) {
     currentURL = currentURL.substring(0, currentURL.indexOf("?"));
@@ -473,6 +474,9 @@ var protect_svg = '<svg t="1629560538805" class="icon" viewBox="0 0 1024 1024" v
     saveJss += "setTimeout(function() {location.reload();},200)";
     saveJss += "}</script>";
     $("body").append(saveJss);
+
+    $("body")["0"].innerHTML = $("body")["0"].innerHTML.replaceAll("gitcode.com","github.com");
+    $("body")["0"].innerHTML = $("body")["0"].innerHTML.replaceAll("?utm_source=artical_gitcode","");
 
     setTimeout(function() {
         var blockURL = currentURL.split("/").length;

--- a/csdngreener_openuserjs.user.js
+++ b/csdngreener_openuserjs.user.js
@@ -7,7 +7,7 @@
 // @contributionURL https://doc.stackoverflow.wiki/web/#/21?page_id=138
 // @name         最强的老牌脚本CSDNGreener：CSDN广告完全过滤、人性化脚本优化
 // @namespace    https://github.com/adlered
-// @version      4.2.3
+// @version      4.2.4
 // @description  全新4.0版本！拥有数项独家功能的最强CSDN脚本，不服比一比|无需登录CSDN，获得比会员更佳的体验|背景图自定义，模块化卡片，显示什么你决定|分辨率自适配，分屏不用滚动|超级预优化|独家原创文章免登录展开|独家推荐内容自由开关|独家免登录复制|独家防外链重定向|独家论坛未登录自动展开文章、评论|全面净化|沉浸阅读|净化剪贴板
 // @connect      www.csdn.net
 // @include      *://*.csdn.net/*
@@ -20,6 +20,7 @@
 // @grant        GM_getValue
 // @license      AGPL-3.0-or-later
 // @antifeature  ads CSDNGreener 脚本中嵌入了可一键永久关闭的小广告，不会影响您的使用体验:) 请放心安装！
+// @note	 24-03-28 4.2.4 批量替换gitcode为github
 // @note	 24-03-28 4.2.3 跟随更新
 // @note         23-12-21 4.2.2 修复了一些已知问题
 // @note         23-12-16 4.2.1 文章页牛皮癣优化
@@ -173,7 +174,7 @@
 // @note         19-03-01 1.0.1 修复了排版问题, 优化了代码结构
 // @note         19-02-26 1.0.0 初版发布
 // ==/UserScript==
-var version = "4.2.3";
+var version = "4.2.4";
 var currentURL = window.location.href;
 if (currentURL.indexOf("?") !== -1) {
     currentURL = currentURL.substring(0, currentURL.indexOf("?"));
@@ -482,6 +483,9 @@ var protect_svg = '<svg t="1629560538805" class="icon" viewBox="0 0 1024 1024" v
     saveJss += "setTimeout(function() {location.reload();},200)";
     saveJss += "}</script>";
     $("body").append(saveJss);
+
+    $("body")["0"].innerHTML = $("body")["0"].innerHTML.replaceAll("gitcode.com","github.com");
+    $("body")["0"].innerHTML = $("body")["0"].innerHTML.replaceAll("?utm_source=artical_gitcode","");
 
     setTimeout(function() {
         var blockURL = currentURL.split("/").length;


### PR DESCRIPTION
最近，CSDN旗下的gitcode将github上的仓库批量镜像，同时将CSDN中所有的github链接替换为gitcode。
但是绝大部分的gitcode链接均无法访问，且众多开发者强烈反对，遂提出此PR。