### PR TITLE
🎨 4.2.5 移除复制按钮旁边的推广

### DIFF
--- a/csdngreener_greasyfork.user.js
+++ b/csdngreener_greasyfork.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         「CSDNGreener」🍃CSDN广告完全过滤|免登录|个性化排版|最强老牌脚本|持续更新
 // @namespace    https://github.com/adlered
-// @version      4.2.4
+// @version      4.2.5
 // @description  ⚡️全新4.0版本！拥有数项独家功能的最强CSDN脚本，不服比一比⚡️|🕶无需登录CSDN，获得比会员更佳的体验|🖥自定义背景图，分辨率自适配，分屏不用滚动|💾超级预优化|🏷原创文章免登录展开|🔌独家推荐内容自由开关|📠免登录复制|🔗防外链重定向|📝独家论坛未登录自动展开文章、评论|🌵全面净化|📈沉浸阅读|🧴净化剪贴板|📕作者信息文章顶部展示
 // @author       Adler
 // @connect      www.csdn.net
@@ -16,6 +16,7 @@
 // @grant        GM_getValue
 // @license      AGPL-3.0-or-later
 // @antifeature  ads CSDNGreener 脚本中嵌入了可一键永久关闭的小广告，不会影响您的使用体验:) 请放心安装！
+// @note         25-03-31 4.2.5 移除复制按钮旁边的推广
 // @note         24-07-18 4.2.4 描述更改
 // @note         24-03-28 4.2.3 标题更改
 // @note         23-12-21 4.2.2 修复了一些已知问题
@@ -165,7 +166,7 @@
 // @downloadURL https://update.greasyfork.org/scripts/378351/%F0%9F%94%A5%E6%8C%81%E7%BB%AD%E6%9B%B4%E6%96%B0%F0%9F%94%A5%20CSDN%E5%B9%BF%E5%91%8A%E5%AE%8C%E5%85%A8%E8%BF%87%E6%BB%A4%E3%80%81%E4%BA%BA%E6%80%A7%E5%8C%96%E8%84%9A%E6%9C%AC%E4%BC%98%E5%8C%96%EF%BC%9A%F0%9F%86%95%20%E4%B8%8D%E7%94%A8%E5%86%8D%E7%99%BB%E5%BD%95%E4%BA%86%EF%BC%81%E8%AE%A9%E4%BD%A0%E4%BD%93%E9%AA%8C%E4%BB%A4%E4%BA%BA%E6%83%8A%E5%96%9C%E7%9A%84%E5%B4%AD%E6%96%B0CSDN%E3%80%82.user.js
 // @updateURL https://update.greasyfork.org/scripts/378351/%F0%9F%94%A5%E6%8C%81%E7%BB%AD%E6%9B%B4%E6%96%B0%F0%9F%94%A5%20CSDN%E5%B9%BF%E5%91%8A%E5%AE%8C%E5%85%A8%E8%BF%87%E6%BB%A4%E3%80%81%E4%BA%BA%E6%80%A7%E5%8C%96%E8%84%9A%E6%9C%AC%E4%BC%98%E5%8C%96%EF%BC%9A%F0%9F%86%95%20%E4%B8%8D%E7%94%A8%E5%86%8D%E7%99%BB%E5%BD%95%E4%BA%86%EF%BC%81%E8%AE%A9%E4%BD%A0%E4%BD%93%E9%AA%8C%E4%BB%A4%E4%BA%BA%E6%83%8A%E5%96%9C%E7%9A%84%E5%B4%AD%E6%96%B0CSDN%E3%80%82.meta.js
 // ==/UserScript==
-var version = "4.2.4";
+var version = "4.2.5";
 var currentURL = window.location.href;
 if (currentURL.indexOf("?") !== -1) {
     currentURL = currentURL.substring(0, currentURL.indexOf("?"));
@@ -1010,6 +1011,10 @@ function common(num, times) {
             }
             // 去除推广广告
             $("li[data-type='ad']").remove();
+            // 移除AI写代码按钮
+            $(".btn-code-notes").remove();
+            // 复制按钮对齐
+            $(".hljs-button").removeClass("add_def");
             // 免登录复制
             $(".hljs-button").removeClass("signin");
             $(".hljs-button").addClass("{2}");

--- a/csdngreener_openuserjs.user.js
+++ b/csdngreener_openuserjs.user.js
@@ -7,7 +7,7 @@
 // @contributionURL https://doc.stackoverflow.wiki/web/#/21?page_id=138
 // @name         最强的老牌脚本CSDNGreener：CSDN广告完全过滤、人性化脚本优化
 // @namespace    https://github.com/adlered
-// @version      4.2.3
+// @version      4.2.5
 // @description  全新4.0版本！拥有数项独家功能的最强CSDN脚本，不服比一比|无需登录CSDN，获得比会员更佳的体验|背景图自定义，模块化卡片，显示什么你决定|分辨率自适配，分屏不用滚动|超级预优化|独家原创文章免登录展开|独家推荐内容自由开关|独家免登录复制|独家防外链重定向|独家论坛未登录自动展开文章、评论|全面净化|沉浸阅读|净化剪贴板
 // @connect      www.csdn.net
 // @include      *://*.csdn.net/*
@@ -20,7 +20,9 @@
 // @grant        GM_getValue
 // @license      AGPL-3.0-or-later
 // @antifeature  ads CSDNGreener 脚本中嵌入了可一键永久关闭的小广告，不会影响您的使用体验:) 请放心安装！
-// @note	 24-03-28 4.2.3 跟随更新
+// @note         25-03-31 4.2.5 移除复制按钮旁边的推广
+// @note         25-03-31 4.2.4 跟随更新
+// @note         24-03-28 4.2.3 跟随更新
 // @note         23-12-21 4.2.2 修复了一些已知问题
 // @note         23-12-16 4.2.1 文章页牛皮癣优化
 // @note         23-12-15 4.2.0 优化顶栏显示内容，修复了若干由于CSDN前端变化导致优化失效的问题
@@ -173,7 +175,7 @@
 // @note         19-03-01 1.0.1 修复了排版问题, 优化了代码结构
 // @note         19-02-26 1.0.0 初版发布
 // ==/UserScript==
-var version = "4.2.3";
+var version = "4.2.5";
 var currentURL = window.location.href;
 if (currentURL.indexOf("?") !== -1) {
     currentURL = currentURL.substring(0, currentURL.indexOf("?"));
@@ -1018,6 +1020,10 @@ function common(num, times) {
             }
             // 去除推广广告
             $("li[data-type='ad']").remove();
+            // 移除AI写代码按钮
+            $(".btn-code-notes").remove();
+            // 复制按钮对齐
+            $(".hljs-button").removeClass("add_def");
             // 免登录复制
             $(".hljs-button").removeClass("signin");
             $(".hljs-button").addClass("{2}");


### PR DESCRIPTION
1. 首先抱歉，由于对vs code GUI 操作的不熟悉，导致提交了混乱的分支。现在删除了之前的fork，重新PR。
2. 没能测试csdngreener_openuserjs.user.js，只测试了油猴脚本。但对比代码部分几乎一样，故在对应位置上的修改应该可行？
